### PR TITLE
Remove hardcoded ids

### DIFF
--- a/kiwi/constants.py
+++ b/kiwi/constants.py
@@ -22,21 +22,9 @@ START = '<bos>'
 STOP = '<eos>'
 UNALIGNED = '<unaligned>'
 
-# special tokens id (don't edit this order)
-# FIXME: avoid using these IDs since we don't really make sure they correspond
-# to the above tokens
-UNK_ID = 0
-PAD_ID = 1
-START_ID = 2
-STOP_ID = 3
-UNALIGNED_ID = 4
-
-PAD_TAGS_ID = 2
 # binary labels
 OK = 'OK'
 BAD = 'BAD'
-OK_ID = 0
-BAD_ID = 1
 LABELS = [OK, BAD]
 
 # this should be removed in the future

--- a/kiwi/data/fields/qe_field.py
+++ b/kiwi/data/fields/qe_field.py
@@ -69,7 +69,6 @@ class QEField(data.Field):
             OrderedDict.fromkeys(
                 tok
                 for tok in [
-                    self.unk_token,
                     self.pad_token,
                     self.init_token,
                     self.eos_token,
@@ -78,4 +77,6 @@ class QEField(data.Field):
                 if tok is not None
             )
         )
-        self.vocab = self.vocab_cls(counter, specials=specials, **kwargs)
+        self.vocab = self.vocab_cls(
+            counter, specials=specials, unk=UNK, **kwargs
+        )

--- a/kiwi/data/fields/sequence_labels_field.py
+++ b/kiwi/data/fields/sequence_labels_field.py
@@ -16,23 +16,28 @@
 #
 
 from collections import Counter
+import copy
 
 from torchtext.data import Field
+from kiwi.data.vocabulary import Vocabulary
+from kiwi import constants as const
 
 
 class SequenceLabelsField(Field):
     """Sequence of Labels.
     """
 
-    def __init__(self, classes, *args, **kwargs):
+    def __init__(self, classes=None, vocab_cls=Vocabulary, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if classes is None:
+            classes = const.LABELS
         self.classes = classes
         self.vocab = None
-        super().__init__(*args, **kwargs)
+        self.vocab_cls = vocab_cls
 
     def build_vocab(self, *args, **kwargs):
-        specials = self.classes + [
-            self.pad_token,
-            self.init_token,
-            self.eos_token,
-        ]
+        specials = copy.copy(self.classes)
+        if self.pad_token:
+            specials.append(self.pad_token)
+        # cnt = Counter({class_name: 1 for class_name in self.classes})
         self.vocab = self.vocab_cls(Counter(), specials=specials, **kwargs)

--- a/kiwi/data/fieldsets/linear.py
+++ b/kiwi/data/fieldsets/linear.py
@@ -24,6 +24,7 @@ from kiwi.data.corpus import Corpus
 from kiwi.data.fields.alignment_field import AlignmentField
 from kiwi.data.fields.qe_field import QEField
 from kiwi.data.fieldsets.fieldset import Fieldset
+from kiwi.data.fields.sequence_labels_field import SequenceLabelsField
 from kiwi.data.tokenizers import align_tokenizer, tokenizer
 
 
@@ -41,9 +42,7 @@ def build_fieldset():
     target_field = QEField(tokenize=tokenizer)
     source_pos = QEField(tokenize=tokenizer)
     target_pos = QEField(tokenize=tokenizer)
-    target_tags_field = data.Field(
-        tokenize=tokenizer, pad_token=None, unk_token=None
-    )
+    target_tags_field = SequenceLabelsField(tokenize=tokenizer, pad_token=None)
 
     fs.add(
         name=const.SOURCE,

--- a/kiwi/data/fieldsets/predictor.py
+++ b/kiwi/data/fieldsets/predictor.py
@@ -15,32 +15,20 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from torchtext import data
-
 from kiwi import constants as const
-from kiwi.data.fields.sequence_labels_field import SequenceLabelsField
+from kiwi.data.fields.qe_field import QEField
 from kiwi.data.fieldsets.fieldset import Fieldset
 from kiwi.data.tokenizers import tokenizer
 
 
 def build_text_field():
-    return data.Field(
+    return QEField(
         tokenize=tokenizer,
         init_token=const.START,
         batch_first=True,
         eos_token=const.STOP,
         pad_token=const.PAD,
         unk_token=const.UNK,
-    )
-
-
-def build_label_field(postprocessing=None):
-    return SequenceLabelsField(
-        classes=const.LABELS,
-        tokenize=tokenizer,
-        pad_token=const.PAD,
-        batch_first=True,
-        postprocessing=postprocessing,
     )
 
 

--- a/kiwi/data/fieldsets/predictor_estimator.py
+++ b/kiwi/data/fieldsets/predictor_estimator.py
@@ -22,18 +22,8 @@ from kiwi import constants as const
 from kiwi.data import utils
 from kiwi.data.fields.sequence_labels_field import SequenceLabelsField
 from kiwi.data.fieldsets.fieldset import Fieldset
+from kiwi.data.fieldsets.predictor import build_text_field
 from kiwi.data.tokenizers import tokenizer
-
-
-def build_text_field():
-    return data.Field(
-        tokenize=tokenizer,
-        init_token=const.START,
-        batch_first=True,
-        eos_token=const.STOP,
-        pad_token=const.PAD,
-        unk_token=const.UNK,
-    )
 
 
 def build_label_field(postprocessing=None):

--- a/kiwi/data/forgetful_defaultdict.py
+++ b/kiwi/data/forgetful_defaultdict.py
@@ -1,0 +1,12 @@
+class ForgetfulDefaultdict(dict):
+    """Defaultdict that does not cache values.
+    """
+    def __init__(self, default, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.default = default
+
+    def __getitem__(self, key):
+        if key in self:
+            return super().__getitem__(key)
+        else:
+            return self.default

--- a/kiwi/data/utils.py
+++ b/kiwi/data/utils.py
@@ -17,7 +17,6 @@
 
 import copy
 import logging
-from collections import defaultdict
 from math import ceil
 from pathlib import Path
 
@@ -36,22 +35,16 @@ def serialize_vocabs(vocabs, include_vectors=False):
 
     for name, vocab in vocabs.items():
         vocab = copy.copy(vocab)
-        vocab.stoi = dict(vocab.stoi)
         if not include_vectors:
             vocab.vectors = None
         serialized_vocabs.append((name, vocab))
-
     return serialized_vocabs
 
 
 def deserialize_vocabs(vocabs):
     """Restore defaultdict lost in serialization.
     """
-    vocabs = dict(vocabs)
-    for name, vocab in vocabs.items():
-        # Hack. Can't pickle defaultdict :(
-        vocab.stoi = defaultdict(lambda: const.UNK_ID, vocab.stoi)
-    return vocabs
+    return dict(vocabs)
 
 
 def serialize_fields_to_vocabs(fields):
@@ -68,8 +61,7 @@ def deserialize_fields_from_vocabs(fields, vocabs):
     """
     Load serialized vocabularies into their fields.
     """
-    # TODO redundant deserialization
-    vocabs = deserialize_vocabs(vocabs)
+    # TODO redundant method
     return fields_from_vocabs(fields, vocabs)
 
 
@@ -78,7 +70,7 @@ def fields_from_vocabs(fields, vocabs):
     Load Field objects from vocabs dict.
     From OpenNMT
     """
-    vocabs = deserialize_vocabs(vocabs)
+    vocabs = dict(vocabs)
     for name, vocab in vocabs.items():
         if name not in fields:
             logger.debug(
@@ -152,7 +144,6 @@ def build_vocabulary(fields_vocab_options, *datasets):
     fields = {}
     for dataset in datasets:
         fields.update(dataset.fields)
-
     for name, field in fields.items():
         if not vocab_loaded_if_needed(field):
             kwargs_vocab = fields_vocab_options[name]

--- a/kiwi/data/vocabulary.py
+++ b/kiwi/data/vocabulary.py
@@ -16,15 +16,11 @@
 #
 
 import warnings
-from collections import defaultdict
 
 import torchtext
 
-from kiwi.constants import PAD, START, STOP, UNALIGNED, UNK, UNK_ID
-
-
-def _default_unk_index():
-    return UNK_ID  # should be zero
+from kiwi.constants import PAD, START, STOP, UNALIGNED
+from kiwi.data.forgetful_defaultdict import ForgetfulDefaultdict
 
 
 class Vocabulary(torchtext.vocab.Vocab):
@@ -33,7 +29,7 @@ class Vocabulary(torchtext.vocab.Vocab):
     Attributes:
         freqs: A collections.Counter object holding the frequencies of tokens
             in the data used to build the Vocab.
-        stoi: A collections.defaultdict instance mapping token strings to
+        stoi: A dict instance mapping token strings to
             numerical identifiers.
         itos: A list of token strings indexed by their numerical identifiers.
     """
@@ -49,6 +45,7 @@ class Vocabulary(torchtext.vocab.Vocab):
         vectors_cache=None,
         rare_with_vectors=True,
         add_vectors_vocab=False,
+        unk=False
     ):
         """Create a Vocab object from a collections.Counter.
 
@@ -79,10 +76,14 @@ class Vocabulary(torchtext.vocab.Vocab):
                 vocabulary will add words that are not in the datasets but are
                 in the vectors vocabulary (e.g. words from polyglot vectors).
                 Default: False.
+            unk: Unknown Token
         """
         if specials is None:
-            specials = ['<pad>']
-
+            specials = []
+        self.unk = unk
+        if self.unk:
+            specials = [self.unk] + specials
+        self.specials = specials
         self.freqs = counter
         counter = counter.copy()
         min_freq = max(min_freq, 1)
@@ -132,23 +133,34 @@ class Vocabulary(torchtext.vocab.Vocab):
             v_itos = vset - set(self.itos)
             self.itos.extend(list(v_itos))
 
-        self.stoi = defaultdict(_default_unk_index)
+        self.stoi = dict()
         # stoi is simply a reverse dict for itos
         self.stoi.update({tok: i for i, tok in enumerate(self.itos)})
 
+        if self.unk:  # defaultdict that does not insert keys upon lookup
+            self.stoi = ForgetfulDefaultdict(self.stoi[self.unk], self.stoi)
         self.vectors = None
         if vectors is not None:
             self.load_vectors(vectors, unk_init=unk_init, cache=vectors_cache)
         else:
             assert unk_init is None and vectors_cache is None
 
+    def token_to_id(self, token):
+        if token in self.stoi or self.unk is not None:
+            return self.stoi[token]
+        raise ValueError('Token {} not in Vocabulary!'.format(token))
+
+    def id_to_token(self, idx):
+        return self.itos[idx]
+
 
 def merge_vocabularies(vocab_a, vocab_b, max_size=None, vectors=None, **kwargs):
     merged = vocab_a.freqs + vocab_b.freqs
     return Vocabulary(
         merged,
-        specials=[UNK, PAD, START, STOP, UNALIGNED],
+        specials=[PAD, START, STOP, UNALIGNED],
         max_size=max_size,
         vectors=vectors,
-        **kwargs,
+        unk=vocab_a.unk or vocab_b.unk,  # use unk if either a or b used unk
+        **kwargs
     )

--- a/kiwi/metrics/__init__.py
+++ b/kiwi/metrics/__init__.py
@@ -25,5 +25,4 @@ CorrectMetric = metrics.CorrectMetric
 RMSEMetric = metrics.RMSEMetric
 PearsonMetric = metrics.PearsonMetric
 SpearmanMetric = metrics.SpearmanMetric
-TokenMetric = metrics.TokenMetric
 ThresholdCalibrationMetric = metrics.ThresholdCalibrationMetric

--- a/kiwi/metrics/metrics.py
+++ b/kiwi/metrics/metrics.py
@@ -24,7 +24,6 @@ import torch
 from scipy.stats.stats import pearsonr, spearmanr
 from torch import nn
 
-from kiwi import constants as const
 from kiwi.metrics.functions import fscore, precision_recall_fscore_support
 from kiwi.models.utils import replace_token
 
@@ -318,36 +317,16 @@ class RMSEMetric(Metric):
         self.tokens = 0
 
 
-class TokenMetric(Metric):
-    def __init__(self, target_token=const.UNK_ID, token_name='UNK', **kwargs):
-        self.target_token = target_token
-        super().__init__(metric_name='UNKS', **kwargs)
-
-    def update(self, batch, **kwargs):
-        target = self.get_target_flat(batch)
-        self.targets += (target == self.target_token).sum().item()
-        self.tokens += self.get_tokens(batch)
-
-    def summarize(self):
-        summary = {}
-        if self.tokens:
-            summary = {self.metric_name: self.targets / self.tokens}
-        return self._prefix_keys(summary)
-
-    def reset(self):
-        self.tokens = 0
-        self.targets = 0
-
-
 class ThresholdCalibrationMetric(Metric):
-    def __init__(self, **kwargs):
+    def __init__(self, target_id=0, **kwargs):
+        self.target_id = target_id
         super().__init__(metric_name='F1_CAL', **kwargs)
 
     def update(self, model_out, batch, **kwargs):
         logits = self.get_predictions_flat(model_out, batch)
-        bad_probs = nn.functional.softmax(logits, -1)[:, const.BAD_ID]
+        probs = nn.functional.softmax(logits, -1)[:, self.target_id]
         target = self.get_target_flat(batch)
-        self.scores += bad_probs.tolist()
+        self.probs += probs.tolist()
         self.Y += target.tolist()
 
     def summarize(self):
@@ -356,15 +335,18 @@ class ThresholdCalibrationMetric(Metric):
         if mid:
             perm = np.random.permutation(len(self.Y))
             self.Y = [self.Y[idx] for idx in perm]
-            self.scores = [self.scores[idx] for idx in perm]
+            self.probs = [self.probs[idx] for idx in perm]
             m = MovingF1()
             fscore, threshold = m.choose(
-                m.eval(self.scores[:mid], self.Y[:mid])
+                m.eval(self.probs[:mid], self.Y[:mid])
             )
-            predictions = [
-                const.BAD_ID if score >= threshold else const.OK_ID
-                for score in self.scores[mid:]
-            ]
+
+            predictions = []
+            for prob in self.probs[mid:]:
+                if prob >= threshold:
+                    predictions.append(self.target_id)
+                else:
+                    predictions.append(max(0, 1 - self.target_id))
             _, _, f1, _ = precision_recall_fscore_support(
                 predictions, self.Y[mid:]
             )
@@ -373,7 +355,7 @@ class ThresholdCalibrationMetric(Metric):
         return self._prefix_keys(summary)
 
     def reset(self):
-        self.scores = []
+        self.probs = []
         self.Y = []
 
 

--- a/kiwi/models/nuqe.py
+++ b/kiwi/models/nuqe.py
@@ -21,7 +21,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from kiwi import constants as const
 from kiwi.data.fieldsets.quetch import build_fieldset
 from kiwi.models.model import Model
 from kiwi.models.quetch import QUETCH
@@ -54,14 +53,17 @@ class NuQE(QUETCH):
         super().__init__(vocabs, **kwargs)
 
     def build(self, source_vectors=None, target_vectors=None):
-        nb_classes = self.config.nb_classes
-        # FIXME: Remove dependency on magic number
+        nb_classes = self.config.nb_classes[self.config.target_tags]
         weight = make_loss_weights(
-            nb_classes, const.BAD_ID, self.config.bad_weight
+            nb_classes,
+            self.config.bad_idx[self.config.target_tags],
+            self.config.bad_weight
         )
 
         self._loss = nn.CrossEntropyLoss(
-            weight=weight, ignore_index=self.config.tags_pad_id, reduction='sum'
+            weight=weight,
+            ignore_index=self.config.pad_idx[self.config.target_tags],
+            reduction='sum'
         )
 
         # Embeddings layers:
@@ -77,7 +79,6 @@ class NuQE(QUETCH):
         l3_dim = self.config.hidden_sizes[2]
         l4_dim = self.config.hidden_sizes[3]
 
-        nb_classes = self.config.nb_classes
         dropout = self.config.dropout
 
         # Linear layers
@@ -147,13 +148,8 @@ class NuQE(QUETCH):
     def forward(self, batch):
         assert self.is_built
 
-        if self.config.predict_source:
-            align_side = const.SOURCE_TAGS
-        else:
-            align_side = const.TARGET_TAGS
-
         target_input, source_input, nb_alignments = self.make_input(
-            batch, align_side
+            batch, self.config.target_tags
         )
 
         #
@@ -248,12 +244,5 @@ class NuQE(QUETCH):
         # h = F.log_softmax(h, dim=-1)
 
         outputs = OrderedDict()
-
-        if self.config.predict_target:
-            outputs[const.TARGET_TAGS] = h
-        if self.config.predict_gaps:
-            outputs[const.GAP_TAGS] = h
-        if self.config.predict_source:
-            outputs[const.SOURCE_TAGS] = h
-
+        outputs[self.config.target_tags] = h
         return outputs

--- a/kiwi/models/predictor.py
+++ b/kiwi/models/predictor.py
@@ -31,7 +31,6 @@ from kiwi.models.utils import apply_packed_sequence, replace_token
 class PredictorConfig(ModelConfig):
     def __init__(
         self,
-        vocabs,
         hidden_pred=400,
         rnn_layers_pred=3,
         dropout_pred=0.0,
@@ -41,10 +40,11 @@ class PredictorConfig(ModelConfig):
         source_embeddings_size=200,
         out_embeddings_size=200,
         predict_inverse=False,
+        **kwargs
     ):
         """Predictor Hyperparams.
         """
-        super().__init__(vocabs)
+        super().__init__(**kwargs)
 
         # Vocabulary
         self.target_side = const.TARGET
@@ -54,10 +54,6 @@ class PredictorConfig(ModelConfig):
             self.source_side, self.target_side = (
                 self.target_side,
                 self.source_side,
-            )
-            self.target_vocab_size, self.source_vocab_size = (
-                self.source_vocab_size,
-                self.target_vocab_size,
             )
 
         # Architecture
@@ -111,14 +107,14 @@ class Predictor(Model):
 
         self.attention = Attention(scorer)
         self.embedding_source = nn.Embedding(
-            self.config.source_vocab_size,
+            self.config.vocab_sizes[self.config.source_side],
             self.config.source_embeddings_size,
-            const.PAD_ID,
+            self.config.pad_idx[self.config.source_side],
         )
         self.embedding_target = nn.Embedding(
-            self.config.target_vocab_size,
+            self.config.vocab_sizes[self.config.target_side],
             self.config.target_embeddings_size,
-            const.PAD_ID,
+            self.config.pad_idx[self.config.target_side],
         )
         self.lstm_source = nn.LSTM(
             input_size=self.config.source_embeddings_size,
@@ -148,9 +144,9 @@ class Predictor(Model):
         self.W1 = self.embedding_target
         if not self.config.share_embeddings:
             self.W1 = nn.Embedding(
-                self.config.target_vocab_size,
+                self.config.vocab_sizes[self.config.target_side],
                 self.config.out_embeddings_size,
-                const.PAD_ID,
+                self.config.pad_idx[self.config.target_side],
             )
         self.W2 = nn.Parameter(
             torch.zeros(
@@ -178,7 +174,8 @@ class Predictor(Model):
                 nn.init.xavier_uniform_(p)
 
         self._loss = nn.CrossEntropyLoss(
-            reduction='sum', ignore_index=const.PAD_ID
+            reduction='sum',
+            ignore_index=(self.config.pad_idx[self.config.target_side]),
         )
 
     @staticmethod
@@ -217,7 +214,11 @@ class Predictor(Model):
             target_side = self.config.target_side
         target = getattr(batch, target_side)
         # There are no predictions for first/last element
-        target = replace_token(target[:, 1:-1], const.STOP_ID, const.PAD_ID)
+        target = replace_token(
+            target[:, 1:-1],
+            self.config.stop_idx[self.config.target_side],
+            self.config.pad_idx[self.config.target_side]
+        )
         # Predicted Class must be in dim 1 for xentropyloss
         logits = model_out[target_side]
         logits = logits.transpose(1, 2)
@@ -335,8 +336,8 @@ class Predictor(Model):
         main_metric = PerplexityMetric(
             prefix=self.config.target_side,
             target_name=self.config.target_side,
-            PAD=const.PAD_ID,
-            STOP=const.STOP_ID,
+            PAD=self.config.pad_idx[self.config.target_side],
+            STOP=self.config.stop_idx[self.config.target_side],
         )
         metrics.append(main_metric)
 
@@ -344,16 +345,16 @@ class Predictor(Model):
             CorrectMetric(
                 prefix=self.config.target_side,
                 target_name=self.config.target_side,
-                PAD=const.PAD_ID,
-                STOP=const.STOP_ID,
+                PAD=self.config.pad_idx[self.config.target_side],
+                STOP=self.config.stop_idx[self.config.target_side],
             )
         )
         metrics.append(
             ExpectedErrorMetric(
                 prefix=self.config.target_side,
                 target_name=self.config.target_side,
-                PAD=const.PAD_ID,
-                STOP=const.STOP_ID,
+                PAD=self.config.pad_idx[self.config.target_side],
+                STOP=self.config.stop_idx[self.config.target_side],
             )
         )
         return metrics

--- a/kiwi/models/quetch.py
+++ b/kiwi/models/quetch.py
@@ -89,6 +89,15 @@ class QUETCHConfig(QEModelConfig):
             vocabs[const.TARGET].token_to_id(const.UNALIGNED)
         )
 
+    @staticmethod
+    def convert_serial_format(config_dict, kwargs):
+        config_dict, kwargs = (super(QUETCHConfig, QUETCHConfig)
+                               .convert_serial_format(config_dict, kwargs))
+        if '__version__' not in config_dict:
+            del config_dict['nb_classes']
+        return config_dict, kwargs
+
+
 
 @Model.register_subclass
 class QUETCH(Model):

--- a/kiwi/models/quetch.py
+++ b/kiwi/models/quetch.py
@@ -74,12 +74,6 @@ class QUETCHConfig(QEModelConfig):
         self.dropout = dropout
         self.embeddings_dropout = embeddings_dropout
         self.freeze_embeddings = freeze_embeddings
-        # self.predict_side = predict_side
-
-        # if predicting tags or source, default predict_target=true
-        # doesn't make sense
-        if predict_gaps or predict_source:
-            predict_target = predict_target
         self.predict_target = predict_target
         self.predict_gaps = predict_gaps
         self.predict_source = predict_source

--- a/kiwi/models/quetch.py
+++ b/kiwi/models/quetch.py
@@ -98,7 +98,6 @@ class QUETCHConfig(QEModelConfig):
         return config_dict, kwargs
 
 
-
 @Model.register_subclass
 class QUETCH(Model):
     """QUality Estimation from scraTCH (QUETCH) model.

--- a/kiwi/models/quetch.py
+++ b/kiwi/models/quetch.py
@@ -24,11 +24,11 @@ import torch.nn.functional as F
 from kiwi import constants as const
 from kiwi.data.fieldsets.quetch import build_fieldset
 from kiwi.metrics import CorrectMetric, F1Metric, LogMetric
-from kiwi.models.model import Model, ModelConfig
+from kiwi.models.model import Model, QEModelConfig
 from kiwi.models.utils import align_tensor, convolve_tensor, make_loss_weights
 
 
-class QUETCHConfig(ModelConfig):
+class QUETCHConfig(QEModelConfig):
     def __init__(
         self,
         vocabs,
@@ -45,7 +45,17 @@ class QUETCHConfig(ModelConfig):
         embeddings_dropout=0.4,
         freeze_embeddings=False,
     ):
-        super().__init__(vocabs)
+        super().__init__(vocabs, predict_target, predict_source, predict_gaps)
+
+        assert(sum((predict_target, predict_gaps, predict_source)) == 1)
+        self.target_tags = self.output_tags[0]
+        # Swap Directions
+
+        self.target_side, self.source_side = const.TARGET, const.SOURCE
+        if predict_source:
+            self.target_side, self.source_side = (
+                self.source_side, self.target_side,
+            )
 
         if hidden_sizes is None:
             hidden_sizes = [100]
@@ -70,7 +80,6 @@ class QUETCHConfig(ModelConfig):
         # doesn't make sense
         if predict_gaps or predict_source:
             predict_target = predict_target
-
         self.predict_target = predict_target
         self.predict_gaps = predict_gaps
         self.predict_source = predict_source
@@ -79,19 +88,12 @@ class QUETCHConfig(ModelConfig):
         self.max_aligned = max_aligned
         self.hidden_sizes = hidden_sizes
 
-        if const.SOURCE_TAGS in vocabs:
-            self.tags_pad_id = vocabs[const.SOURCE_TAGS].stoi[const.PAD]
-        elif const.GAP_TAGS in vocabs:
-            self.tags_pad_id = vocabs[const.GAP_TAGS].stoi[const.PAD]
-        else:
-            self.tags_pad_id = vocabs[const.TARGET_TAGS].stoi[const.PAD]
-        # FIXME: this might not correspond to reality (in vocabs)!
-        self.nb_classes = len(const.LABELS)
-        self.tag_bad_index = const.BAD_ID
-        self.pad_token = const.PAD
-        self.unaligned_idx = const.UNALIGNED_ID
-        self.source_padding_idx = const.PAD_ID
-        self.target_padding_idx = const.PAD_ID
+        self.source_unaligned_idx = (
+            vocabs[const.SOURCE].token_to_id(const.UNALIGNED)
+        )
+        self.target_unaligned_idx = (
+            vocabs[const.TARGET].token_to_id(const.UNALIGNED)
+        )
 
 
 @Model.register_subclass
@@ -143,19 +145,14 @@ class QUETCH(Model):
         return model
 
     def loss(self, model_out, target):
-        if self.config.predict_source:
-            output_name = const.SOURCE_TAGS
-        elif self.config.predict_gaps:
-            output_name = const.GAP_TAGS
-        else:
-            output_name = const.TARGET_TAGS
-
         # (bs*ts, nb_classes)
-        probs = model_out[output_name]
+        probs = model_out[self.config.target_tags]
         # (bs*ts, )
-        y = getattr(target, output_name)
+        y = getattr(target, self.config.target_tags)
 
-        predicted = probs.view(-1, self.config.nb_classes)
+        predicted = probs.view(
+            -1, self.config.nb_classes[self.config.target_tags]
+        )
         y = y.view(-1)
 
         loss = self._loss(predicted, y)
@@ -168,27 +165,27 @@ class QUETCH(Model):
             self.source_emb = nn.Embedding(
                 num_embeddings=source_vectors.size(0),
                 embedding_dim=source_vectors.size(1),
-                padding_idx=self.config.source_padding_idx,
+                padding_idx=self.config.pad_idx[const.SOURCE],
                 _weight=source_vectors,
             )
         else:
             self.source_emb = nn.Embedding(
-                num_embeddings=self.config.source_vocab_size,
+                num_embeddings=self.config.vocab_sizes[const.SOURCE],
                 embedding_dim=self.config.source_embeddings_size,
-                padding_idx=self.config.source_padding_idx,
+                padding_idx=self.config.pad_idx[const.SOURCE],
             )
         if target_vectors is not None:
             self.target_emb = nn.Embedding(
                 num_embeddings=target_vectors.size(0),
                 embedding_dim=target_vectors.size(1),
-                padding_idx=self.config.target_padding_idx,
+                padding_idx=self.config.pad_idx[const.TARGET],
                 _weight=target_vectors,
             )
         else:
             self.target_emb = nn.Embedding(
-                num_embeddings=self.config.target_vocab_size,
+                num_embeddings=self.config.vocab_sizes[const.TARGET],
                 embedding_dim=self.config.target_embeddings_size,
-                padding_idx=self.config.target_padding_idx,
+                padding_idx=self.config.pad_idx[const.TARGET],
             )
         if self.config.freeze_embeddings:
             self.source_emb.weight.requires_grad = False
@@ -201,15 +198,18 @@ class QUETCH(Model):
     def build(self, source_vectors=None, target_vectors=None):
 
         hidden_size = self.config.hidden_sizes[0]
-        nb_classes = self.config.nb_classes
+        nb_classes = self.config.nb_classes[self.config.target_tags]
         dropout = self.config.dropout
 
         weight = make_loss_weights(
-            nb_classes, const.BAD_ID, self.config.bad_weight
+            nb_classes,
+            self.config.bad_idx[self.config.target_tags],
+            self.config.bad_weight
         )
 
         self._loss = nn.CrossEntropyLoss(
-            weight=weight, ignore_index=const.PAD_TAGS_ID
+            weight=weight,
+            ignore_index=self.config.pad_idx[self.config.target_tags]
         )
 
         # Embeddings layers:
@@ -237,28 +237,28 @@ class QUETCH(Model):
         source_input, source_lengths = getattr(batch, const.SOURCE)
         alignments = batch.alignments
 
-        if self.config.predict_gaps and not self.config.predict_target:
+        if self.config.predict_gaps:
             target_input = F.pad(
                 target_input,
                 pad=(0, 1),
-                value=self.vocabs[const.TARGET].stoi[const.UNALIGNED],
+                value=self.config.target_unaligned_idx,
             )
             source_input = F.pad(
                 source_input,
                 pad=(0, 1),
-                value=self.vocabs[const.SOURCE].stoi[const.UNALIGNED],
+                value=self.config.source_unaligned_idx,
             )
 
         target_input = convolve_tensor(
             target_input,
             self.config.window_size,
-            self.config.target_padding_idx,
+            self.config.pad_idx[const.TARGET],
         )
 
         source_input = convolve_tensor(
             source_input,
             self.config.window_size,
-            self.config.source_padding_idx,
+            self.config.pad_idx[const.SOURCE],
         )
 
         if side == const.SOURCE_TAGS:
@@ -270,8 +270,8 @@ class QUETCH(Model):
                 target_input,
                 alignments,
                 self.config.max_aligned,
-                self.config.unaligned_idx,
-                self.config.target_padding_idx,
+                self.config.target_unaligned_idx,
+                self.config.pad_idx[const.TARGET],
                 pad_size=source_input.shape[1],
             )
         else:
@@ -279,8 +279,8 @@ class QUETCH(Model):
                 source_input,
                 alignments,
                 self.config.max_aligned,
-                self.config.unaligned_idx,
-                self.config.source_padding_idx,
+                self.config.source_unaligned_idx,
+                self.config.pad_idx[const.SOURCE],
                 pad_size=target_input.shape[1],
             )
 
@@ -289,13 +289,8 @@ class QUETCH(Model):
     def forward(self, batch):
         assert self.is_built
 
-        if self.config.predict_source:
-            align_side = const.SOURCE_TAGS
-        else:
-            align_side = const.TARGET_TAGS
-
         target_input, source_input, nb_alignments = self.make_input(
-            batch, align_side
+            batch, self.config.target_tags
         )
 
         #
@@ -347,14 +342,7 @@ class QUETCH(Model):
         h = self.linear_out(h)
 
         outputs = OrderedDict()
-
-        if self.config.predict_target:
-            outputs[const.TARGET_TAGS] = h
-        if self.config.predict_gaps:
-            outputs[const.GAP_TAGS] = h
-        if self.config.predict_source:
-            outputs[const.SOURCE_TAGS] = h
-
+        outputs[self.config.target_tags] = h
         return outputs
 
     @staticmethod
@@ -370,7 +358,7 @@ class QUETCH(Model):
                 F1Metric(
                     prefix=const.TARGET_TAGS,
                     target_name=const.TARGET_TAGS,
-                    PAD=const.PAD_TAGS_ID,
+                    PAD=self.config.pad_idx[self.config.target_tags],
                     labels=const.LABELS,
                 )
             )
@@ -378,7 +366,7 @@ class QUETCH(Model):
                 CorrectMetric(
                     prefix=const.TARGET_TAGS,
                     target_name=const.TARGET_TAGS,
-                    PAD=const.PAD_TAGS_ID,
+                    PAD=self.config.pad_idx[self.config.target_tags],
                 )
             )
         if self.config.predict_source:
@@ -386,7 +374,7 @@ class QUETCH(Model):
                 F1Metric(
                     prefix=const.SOURCE_TAGS,
                     target_name=const.SOURCE_TAGS,
-                    PAD=const.PAD_TAGS_ID,
+                    PAD=self.config.pad_idx[self.config.target_tags],
                     labels=const.LABELS,
                 )
             )
@@ -394,7 +382,7 @@ class QUETCH(Model):
                 CorrectMetric(
                     prefix=const.SOURCE_TAGS,
                     target_name=const.SOURCE_TAGS,
-                    PAD=const.PAD_TAGS_ID,
+                    PAD=self.config.pad_idx[self.config.target_tags],
                 )
             )
         if self.config.predict_gaps:
@@ -402,7 +390,7 @@ class QUETCH(Model):
                 F1Metric(
                     prefix=const.GAP_TAGS,
                     target_name=const.GAP_TAGS,
-                    PAD=const.PAD_TAGS_ID,
+                    PAD=self.config.pad_idx[self.config.target_tags],
                     labels=const.LABELS,
                 )
             )
@@ -410,7 +398,7 @@ class QUETCH(Model):
                 CorrectMetric(
                     prefix=const.GAP_TAGS,
                     target_name=const.GAP_TAGS,
-                    PAD=const.PAD_TAGS_ID,
+                    PAD=self.config.pad_idx[self.config.target_tags],
                 )
             )
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -18,7 +18,7 @@
 import pytest
 
 from conftest import check_computation
-from kiwi import constants
+from kiwi import constants as const
 from kiwi.models.linear_word_qe_classifier import LinearWordQEClassifier
 
 
@@ -29,7 +29,7 @@ def test_train_linear(temp_output_dir, train_opts, linear_opts, atol):
         temp_output_dir,
         train_opts,
         linear_opts,
-        output_name=constants.TARGET_TAGS,
+        output_name=const.TARGET_TAGS,
         expected_avg_probs=0.0,
         atol=atol,
     )
@@ -50,7 +50,7 @@ def test_train_linear(temp_output_dir, train_opts, linear_opts, atol):
 #         for key, values in predictions.items():
 #             train_predictions[key] += values
 #     save_predicted_probabilities(options.output_dir, train_predictions)
-#     train_predictions = train_predictions[constants.TARGET_TAGS]
+#     train_predictions = train_predictions[const.TARGET_TAGS]
 #     avg_of_avgs = np.mean(list(map(np.mean, train_predictions)))
 #     max_prob = max(map(max, train_predictions))
 #     min_prob = min(map(min, train_predictions))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,6 +26,9 @@ from kiwi.data.vocabulary import Vocabulary
 from kiwi.models.model import Model
 
 
+BAD_ID, OK_ID, UNK_ID, PAD_ID, START_ID, STOP_ID = range(6)
+
+
 def test_get_mask():
     target_lengths = torch.LongTensor([1, 2, 3, 4])
     source_lengths = torch.LongTensor([4, 3, 2, 1])
@@ -47,33 +50,33 @@ def test_get_mask():
     gap_mask = target_mask[:, 1:]
     target_tags_mask = target_mask[:, 1:-1]
     source_tags_mask = source_mask[:, 1:-1]
-    source = torch.LongTensor(np.random.randint(4, 100, size=(4, 6)))
-    target = torch.LongTensor(np.random.randint(4, 100, size=(4, 6)))
+    source = torch.LongTensor(np.random.randint(6, 100, size=(4, 6)))
+    target = torch.LongTensor(np.random.randint(6, 100, size=(4, 6)))
     source_tags = torch.LongTensor(np.random.randint(0, 2, size=(4, 4)))
     target_tags = torch.LongTensor(np.random.randint(0, 2, size=(4, 4)))
     gap_tags = torch.LongTensor(np.random.randint(0, 2, size=(4, 5)))
 
-    source = source.masked_fill(1 - source_mask, const.PAD_ID)
-    target = target.masked_fill(1 - target_mask, const.PAD_ID)
+    source = source.masked_fill(1 - source_mask, PAD_ID)
+    target = target.masked_fill(1 - target_mask, PAD_ID)
     target_tags = target_tags.masked_fill(
-        1 - target_tags_mask, const.PAD_TAGS_ID
+        1 - target_tags_mask, PAD_ID
     )
     source_tags = source_tags.masked_fill(
-        1 - source_tags_mask, const.PAD_TAGS_ID
+        1 - source_tags_mask, PAD_ID
     )
-    gap_tags = gap_tags.masked_fill(1 - gap_mask, const.PAD_TAGS_ID)
+    gap_tags = gap_tags.masked_fill(1 - gap_mask, PAD_ID)
 
-    source[:, 0] = const.START_ID
+    source[:, 0] = START_ID
     stop_mask = torch.arange(6).unsqueeze(0).expand_as(source) == (
         (source_lengths + 1).unsqueeze(1)
     )
 
-    source = source.masked_fill(stop_mask, const.STOP_ID)
-    target[:, 0] = const.START_ID
+    source = source.masked_fill(stop_mask, STOP_ID)
+    target[:, 0] = START_ID
     stop_mask = torch.arange(6).unsqueeze(0).expand_as(target) == (
         (target_lengths + 1).unsqueeze(1)
     )
-    target = target.masked_fill(stop_mask, const.STOP_ID)
+    target = target.masked_fill(stop_mask, STOP_ID)
 
     batch = SimpleNamespace(
         **{
@@ -87,13 +90,13 @@ def test_get_mask():
 
     vocab = Vocabulary(collections.Counter())
     vocab.stoi = {
-        const.UNK: const.UNK_ID,
-        const.PAD: const.PAD_ID,
-        const.START: const.START_ID,
-        const.STOP: const.STOP_ID,
+        const.UNK: UNK_ID,
+        const.PAD: PAD_ID,
+        const.START: START_ID,
+        const.STOP: STOP_ID,
     }
     tags_vocab = Vocabulary(collections.Counter())
-    tags_vocab.stoi = {const.PAD: const.PAD_TAGS_ID}
+    tags_vocab.stoi = {const.PAD: PAD_ID}
 
     model = Model(
         vocabs={

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -18,8 +18,20 @@
 import pytest
 
 from kiwi import __version__
-from kiwi import constants
+from kiwi import constants as const
 from kiwi.models.model import ModelConfig
+
+
+class MockVocab(object):
+
+    def __init__(self, length):
+        self.length = length
+
+    def __len__(self):
+        return self.length
+
+    def token_to_id(self, token):
+        return 0
 
 
 @pytest.fixture
@@ -29,32 +41,37 @@ def state_dict():
         'a': None,
         'b': 12,
         'c': 4,
-        'source_vocab_size': 21,
-        'target_vocab_size': 42,
+        'vocab_sizes': {const.SOURCE: 21, const.TARGET: 42},
+        'pad_idx': {const.SOURCE: 0, const.TARGET: 0},
+        'start_idx': {const.SOURCE: 0, const.TARGET: 0},
+        'stop_idx': {const.SOURCE: 0, const.TARGET: 0}
     }
 
 
 @pytest.fixture
 def mock_vocab_one(state_dict):
-    source_vocab_size = state_dict['source_vocab_size']
-    target_vocab_size = state_dict['target_vocab_size']
+    print(state_dict)
+    source_vocab_size = state_dict['vocab_sizes'][const.SOURCE]
+    target_vocab_size = state_dict['vocab_sizes'][const.TARGET]
     return {
-        constants.SOURCE: range(source_vocab_size),
-        constants.TARGET: range(target_vocab_size),
+        const.SOURCE: MockVocab(source_vocab_size),
+        const.TARGET: MockVocab(target_vocab_size),
     }
 
 
 @pytest.fixture
 def mock_vocab_two():
-    return {constants.SOURCE: range(1000), constants.TARGET: range(100)}
+    return {const.SOURCE: MockVocab(1000), const.TARGET: MockVocab(100)}
 
 
 def test_set_vocab_sizes(mock_vocab_one):
-    source_vocab_size = len(mock_vocab_one[constants.SOURCE])
-    target_vocab_size = len(mock_vocab_one[constants.TARGET])
+    source_vocab_size = len(mock_vocab_one[const.SOURCE])
+    target_vocab_size = len(mock_vocab_one[const.TARGET])
+    print(len(mock_vocab_one[const.SOURCE]))
     config = ModelConfig(mock_vocab_one)
-    assert config.source_vocab_size == source_vocab_size
-    assert config.target_vocab_size == target_vocab_size
+    print(config.vocab_sizes)
+    assert config.vocab_sizes[const.SOURCE] == source_vocab_size
+    assert config.vocab_sizes[const.TARGET] == target_vocab_size
 
 
 def test_from_dict(state_dict, mock_vocab_one):
@@ -83,9 +100,16 @@ def test_update_dict(state_dict, mock_vocab_one, mock_vocab_two):
         config_dict=state_dict, vocabs=mock_vocab_one
     )
     config_one.update(config_two.__dict__)
-    for k, v in state_dict.items():
-        assert hasattr(config_one, k)
-        assert getattr(config_one, k) == v
+    for k, v in config_one.state_dict().items():
+        assert k in state_dict
+        if isinstance(v, dict):
+            for _k, _v in v.items():
+                assert _k in state_dict[k]
+                assert _v == state_dict[k][_k]
+        else:
+            assert v == state_dict[k]
+        del state_dict[k]
+    assert not state_dict
 
 
 def test_state_dict(state_dict, mock_vocab_one):
@@ -94,6 +118,11 @@ def test_state_dict(state_dict, mock_vocab_one):
     )
     for k, v in config.state_dict().items():
         assert k in state_dict
-        assert v == state_dict[k]
+        if isinstance(v, dict):
+            for _k, _v in v.items():
+                assert _k in state_dict[k]
+                assert _v == state_dict[k][_k]
+        else:
+            assert v == state_dict[k]
         del state_dict[k]
     assert not state_dict

--- a/tests/test_nuqe.py
+++ b/tests/test_nuqe.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 
 from conftest import check_computation, check_jackknife
-from kiwi import constants
+from kiwi import constants as const
 from kiwi.lib.utils import merge_namespaces, save_config_file
 from kiwi.models.nuqe import NuQE
 
@@ -32,7 +32,7 @@ def test_computation(temp_output_dir, train_opts, nuqe_opts, atol):
         temp_output_dir,
         train_opts,
         nuqe_opts,
-        output_name=constants.TARGET_TAGS,
+        output_name=const.TARGET_TAGS,
         expected_avg_probs=0.572441,
         atol=atol,
     )
@@ -53,14 +53,14 @@ def test_api(temp_output_dir, train_opts, nuqe_opts, atol):
     predicter = load_model(train_run_info.model_path)
 
     examples = {
-        constants.SOURCE: open(nuqe_opts.test_source).readlines(),
-        constants.TARGET: open(nuqe_opts.test_target).readlines(),
-        constants.ALIGNMENTS: open(nuqe_opts.test_alignments).readlines(),
+        const.SOURCE: open(nuqe_opts.test_source).readlines(),
+        const.TARGET: open(nuqe_opts.test_target).readlines(),
+        const.ALIGNMENTS: open(nuqe_opts.test_alignments).readlines(),
     }
 
     predictions = predicter.predict(examples, batch_size=train_opts.batch_size)
 
-    predictions = predictions[constants.TARGET_TAGS]
+    predictions = predictions[const.TARGET_TAGS]
     avg_of_avgs = np.mean(list(map(np.mean, predictions)))
     max_prob = max(map(max, predictions))
     min_prob = min(map(min, predictions))
@@ -74,7 +74,7 @@ def test_jackknifing(temp_output_dir, train_opts, nuqe_opts, atol):
         temp_output_dir,
         train_opts,
         nuqe_opts,
-        output_name=constants.TARGET_TAGS,
+        output_name=const.TARGET_TAGS,
         expected_avg_probs=0.583079,
         atol=atol,
     )

--- a/tests/test_nuqe_18.py
+++ b/tests/test_nuqe_18.py
@@ -18,7 +18,7 @@
 import pytest
 
 from conftest import check_computation, check_jackknife
-from kiwi import constants
+from kiwi import constants as const
 from kiwi.models.nuqe import NuQE
 
 
@@ -61,8 +61,8 @@ def test_computation_target(temp_output_dir, train_opts, target_opts, atol):
         temp_output_dir,
         train_opts,
         target_opts,
-        output_name=constants.TARGET_TAGS,
-        expected_avg_probs=0.466939,
+        output_name=const.TARGET_TAGS,
+        expected_avg_probs=0.485723,
         atol=atol,
     )
 
@@ -73,7 +73,7 @@ def test_computation_gaps(temp_output_dir, train_opts, gap_opts, atol):
         temp_output_dir,
         train_opts,
         gap_opts,
-        output_name=constants.GAP_TAGS,
+        output_name=const.GAP_TAGS,
         expected_avg_probs=0.454558,
         atol=atol,
     )
@@ -85,7 +85,7 @@ def test_computation_source(temp_output_dir, train_opts, source_opts, atol):
         temp_output_dir,
         train_opts,
         source_opts,
-        output_name=constants.SOURCE_TAGS,
+        output_name=const.SOURCE_TAGS,
         expected_avg_probs=0.474266,
         atol=atol,
     )
@@ -97,7 +97,7 @@ def test_jackknifing_target(temp_output_dir, train_opts, target_opts, atol):
         temp_output_dir,
         train_opts,
         target_opts,
-        output_name=constants.TARGET_TAGS,
+        output_name=const.TARGET_TAGS,
         expected_avg_probs=0.477126,
         atol=atol,
     )
@@ -109,7 +109,7 @@ def test_jackknifing_gaps(temp_output_dir, train_opts, gap_opts, atol):
         temp_output_dir,
         train_opts,
         gap_opts,
-        output_name=constants.GAP_TAGS,
+        output_name=const.GAP_TAGS,
         expected_avg_probs=0.526033,
         atol=atol,
     )
@@ -121,8 +121,8 @@ def test_jackknifing_source(temp_output_dir, train_opts, source_opts, atol):
         temp_output_dir,
         train_opts,
         source_opts,
-        output_name=constants.SOURCE_TAGS,
-        expected_avg_probs=0.466141,
+        output_name=const.SOURCE_TAGS,
+        expected_avg_probs=0.471008,
         atol=atol,
     )
 

--- a/tests/test_predest.py
+++ b/tests/test_predest.py
@@ -20,7 +20,7 @@ import argparse
 import pytest
 
 from conftest import check_computation, check_jackknife
-from kiwi import constants
+from kiwi import constants as const
 from kiwi.models.predictor_estimator import Estimator
 
 
@@ -81,8 +81,8 @@ def test_computation_target(temp_output_dir, train_opts, target_opts, atol):
         temp_output_dir,
         train_opts,
         target_opts,
-        output_name=constants.TARGET_TAGS,
-        expected_avg_probs=0.426000,
+        output_name=const.TARGET_TAGS,
+        expected_avg_probs=0.452956,
         atol=atol,
     )
 
@@ -97,8 +97,8 @@ def test_computation_target(temp_output_dir, train_opts, target_opts, atol):
         temp_output_dir,
         resume_opts,
         target_opts,
-        output_name=constants.TARGET_TAGS,
-        expected_avg_probs=0.426000,
+        output_name=const.TARGET_TAGS,
+        expected_avg_probs=0.452956,
         atol=atol,
     )
 
@@ -110,8 +110,8 @@ def test_computation_gaps(temp_output_dir, train_opts, gap_opts, atol):
         temp_output_dir,
         train_opts,
         gap_opts,
-        output_name=constants.GAP_TAGS,
-        expected_avg_probs=0.322811,
+        output_name=const.GAP_TAGS,
+        expected_avg_probs=0.289914,
         atol=atol,
     )
     gap_opts.predict_target = True
@@ -120,8 +120,8 @@ def test_computation_gaps(temp_output_dir, train_opts, gap_opts, atol):
         temp_output_dir,
         train_opts,
         gap_opts,
-        output_name=constants.GAP_TAGS,
-        expected_avg_probs=0.328905,
+        output_name=const.GAP_TAGS,
+        expected_avg_probs=0.331126,
         atol=atol,
     )
 
@@ -132,8 +132,8 @@ def test_computation_source(temp_output_dir, train_opts, source_opts, atol):
         temp_output_dir,
         train_opts,
         source_opts,
-        output_name=constants.SOURCE_TAGS,
-        expected_avg_probs=0.456631,
+        output_name=const.SOURCE_TAGS,
+        expected_avg_probs=0.449527,
         atol=atol,
     )
 
@@ -144,8 +144,8 @@ def test_jackknifing_target(temp_output_dir, train_opts, target_opts, atol):
         temp_output_dir,
         train_opts,
         target_opts,
-        output_name=constants.TARGET_TAGS,
-        expected_avg_probs=0.461057,
+        output_name=const.TARGET_TAGS,
+        expected_avg_probs=0.47876,
         atol=atol,
     )
 
@@ -156,8 +156,8 @@ def test_jackknifing_gaps(temp_output_dir, train_opts, gap_opts, atol):
         temp_output_dir,
         train_opts,
         gap_opts,
-        output_name=constants.GAP_TAGS,
-        expected_avg_probs=0.433703,
+        output_name=const.GAP_TAGS,
+        expected_avg_probs=0.407023,
         atol=atol,
     )
 
@@ -168,8 +168,8 @@ def test_jackknifing_source(temp_output_dir, train_opts, source_opts, atol):
         temp_output_dir,
         train_opts,
         source_opts,
-        output_name=constants.SOURCE_TAGS,
-        expected_avg_probs=0.496570,
+        output_name=const.SOURCE_TAGS,
+        expected_avg_probs=0.484402,
         atol=atol,
     )
 

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from kiwi import constants
+from kiwi import constants as const
 from kiwi.data.builders import build_training_datasets
 from kiwi.data.fieldsets import extend_vocabs_fieldset
 from kiwi.lib import train
@@ -46,15 +46,15 @@ def test_extend_vocabs(extend_vocab):
     dataset, _ = build_training_datasets(
         fieldset, extend_vocabs_fieldset=vocabs_fieldset, **vars(options)
     )
-    assert OOV_SRC in dataset.fields[constants.SOURCE].vocab.stoi
-    assert OOV_TGT in dataset.fields[constants.TARGET].vocab.stoi
+    assert OOV_SRC in dataset.fields[const.SOURCE].vocab.stoi
+    assert OOV_TGT in dataset.fields[const.TARGET].vocab.stoi
 
     fieldset = Predictor.fieldset(wmt18_format=options.wmt18_format)
     options.extend_source_vocab = None
     options.extend_target_vocab = None
     dataset, _ = build_training_datasets(fieldset, **vars(options))
-    assert OOV_SRC not in dataset.fields[constants.SOURCE].vocab.stoi
-    assert OOV_TGT not in dataset.fields[constants.TARGET].vocab.stoi
+    assert OOV_SRC not in dataset.fields[const.SOURCE].vocab.stoi
+    assert OOV_TGT not in dataset.fields[const.TARGET].vocab.stoi
 
 
 def test_train_predictor(temp_output_dir, predictor_opts, train_opts, atol):
@@ -64,7 +64,7 @@ def test_train_predictor(temp_output_dir, predictor_opts, train_opts, atol):
 
     trainer = train.run(Predictor, temp_output_dir, train_opts, predictor_opts)
     stats = trainer.stats_summary_history[-1]
-    np.testing.assert_allclose(stats['target_PERP'], 440.262493, atol=atol)
+    np.testing.assert_allclose(stats['target_PERP'], 410.781112, atol=atol)
 
     # Testing predictor with pickled data
     epoch_dir = 'epoch_{}'.format(train_opts.epochs)
@@ -72,7 +72,7 @@ def test_train_predictor(temp_output_dir, predictor_opts, train_opts, atol):
 
     trainer = train.run(Predictor, temp_output_dir, train_opts, predictor_opts)
     stats = trainer.stats_summary_history[-1]
-    np.testing.assert_allclose(stats['target_PERP'], 420.706878, atol=atol)
+    np.testing.assert_allclose(stats['target_PERP'], 376.099405, atol=atol)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_quetch.py
+++ b/tests/test_quetch.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 
 from conftest import check_computation, check_jackknife
-from kiwi import constants
+from kiwi import constants as const
 from kiwi.lib.utils import merge_namespaces, save_config_file
 from kiwi.models.quetch import QUETCH
 
@@ -32,7 +32,7 @@ def test_computation(temp_output_dir, train_opts, quetch_opts, atol):
         temp_output_dir,
         train_opts,
         quetch_opts,
-        output_name=constants.TARGET_TAGS,
+        output_name=const.TARGET_TAGS,
         expected_avg_probs=0.439731,
         atol=atol,
     )
@@ -55,14 +55,14 @@ def test_api(temp_output_dir, train_opts, quetch_opts, atol):
     predicter = load_model(train_run_info.model_path)
 
     examples = {
-        constants.SOURCE: open(quetch_opts.test_source).readlines(),
-        constants.TARGET: open(quetch_opts.test_target).readlines(),
-        constants.ALIGNMENTS: open(quetch_opts.test_alignments).readlines(),
+        const.SOURCE: open(quetch_opts.test_source).readlines(),
+        const.TARGET: open(quetch_opts.test_target).readlines(),
+        const.ALIGNMENTS: open(quetch_opts.test_alignments).readlines(),
     }
 
     predictions = predicter.predict(examples, batch_size=train_opts.batch_size)
 
-    predictions = predictions[constants.TARGET_TAGS]
+    predictions = predictions[const.TARGET_TAGS]
     avg_of_avgs = np.mean(list(map(np.mean, predictions)))
     max_prob = max(map(max, predictions))
     min_prob = min(map(min, predictions))
@@ -76,7 +76,7 @@ def test_jackknifing(temp_output_dir, train_opts, quetch_opts, atol):
         temp_output_dir,
         train_opts,
         quetch_opts,
-        output_name=constants.TARGET_TAGS,
+        output_name=const.TARGET_TAGS,
         expected_avg_probs=0.486359,
         atol=atol,
     )

--- a/tests/test_quetch_18.py
+++ b/tests/test_quetch_18.py
@@ -18,7 +18,7 @@
 import pytest
 
 from conftest import check_computation, check_jackknife
-from kiwi import constants
+from kiwi import constants as const
 from kiwi.models.quetch import QUETCH
 
 
@@ -61,7 +61,7 @@ def test_computation_target(temp_output_dir, train_opts, target_opts, atol):
         temp_output_dir,
         train_opts,
         target_opts,
-        output_name=constants.TARGET_TAGS,
+        output_name=const.TARGET_TAGS,
         expected_avg_probs=0.361237,
         atol=atol,
     )
@@ -73,7 +73,7 @@ def test_computation_gaps(temp_output_dir, train_opts, gap_opts, atol):
         temp_output_dir,
         train_opts,
         gap_opts,
-        output_name=constants.GAP_TAGS,
+        output_name=const.GAP_TAGS,
         expected_avg_probs=0.251563,
         atol=atol,
     )
@@ -85,8 +85,8 @@ def test_computation_source(temp_output_dir, train_opts, source_opts, atol):
         temp_output_dir,
         train_opts,
         source_opts,
-        output_name=constants.SOURCE_TAGS,
-        expected_avg_probs=0.355306,
+        output_name=const.SOURCE_TAGS,
+        expected_avg_probs=0.358804,
         atol=atol,
     )
 
@@ -97,8 +97,8 @@ def test_jackknifing_target(temp_output_dir, train_opts, target_opts, atol):
         temp_output_dir,
         train_opts,
         target_opts,
-        output_name=constants.TARGET_TAGS,
-        expected_avg_probs=0.372357,
+        output_name=const.TARGET_TAGS,
+        expected_avg_probs=0.403426,
         atol=atol,
     )
 
@@ -109,7 +109,7 @@ def test_jackknifing_gaps(temp_output_dir, train_opts, gap_opts, atol):
         temp_output_dir,
         train_opts,
         gap_opts,
-        output_name=constants.GAP_TAGS,
+        output_name=const.GAP_TAGS,
         expected_avg_probs=0.279053,
         atol=atol,
     )
@@ -121,8 +121,8 @@ def test_jackknifing_source(temp_output_dir, train_opts, source_opts, atol):
         temp_output_dir,
         train_opts,
         source_opts,
-        output_name=constants.SOURCE_TAGS,
-        expected_avg_probs=0.394607,
+        output_name=const.SOURCE_TAGS,
+        expected_avg_probs=0.397483,
         atol=atol,
     )
 


### PR DESCRIPTION
This PR removes the all dependencies on hardcoded IDs and instead retrieves them programatically from the vocabularies when instantiating the model configs.

Other changes included:
 - conversion from old serialization format for backwards compatibility
 - Always use QEField, Vocabulary instead of torchtext Field, Vocab
 - Use a reimplemetation of defaultdict in Vocabulary that does not cache values after key lookup
 - Refactor predictor-estimator forward pass

Things that should still be done:
- Remove code related to serialization of torchtext Vocab
- Remove SequenceLabelField, use QEField instead