### PR TITLE
Add logging options to documentation

### DIFF
--- a/docs/flags.rst
+++ b/docs/flags.rst
@@ -51,3 +51,8 @@ They are divided into three different categories, general, IO and save/load.
    :func: save_load_opts
    :prog: kiwi <pipeline>
 
+.. argparse::
+   :module: kiwi.cli.opts
+   :passparser:
+   :func: logging_opts
+   :prog: kiwi <pipeline>


### PR DESCRIPTION
Fixes #16.

Simply added sphinx options to parse logging options from `kiwi/cli/opts.py`.