### PR TITLE
Fix requirements for training sentence-level estimators

### DIFF
--- a/kiwi/data/fieldsets/predictor_estimator.py
+++ b/kiwi/data/fieldsets/predictor_estimator.py
@@ -88,7 +88,7 @@ def build_fieldset(wmt18_format=False):
             name=const.GAP_TAGS,
             field=build_label_field(post_pipe_gaps),
             file_option_suffix='_target_tags',
-            required=[Fieldset.TRAIN, Fieldset.VALID],
+            required=None,
         )
 
     fieldset.add(

--- a/kiwi/models/predictor_estimator.py
+++ b/kiwi/models/predictor_estimator.py
@@ -99,7 +99,11 @@ class Estimator(Model):
             self.config.update(predictor_tgt.config)
 
         # Predictor Settings #
-        predict_tgt = self.config.predict_target or self.config.predict_gaps
+        predict_tgt = (
+            self.config.predict_target
+            or self.config.predict_gaps
+            or self.config.sentence_level
+        )
         if predict_tgt and not predictor_tgt:
             predictor_tgt = Predictor(
                 vocabs=vocabs,
@@ -312,7 +316,11 @@ class Estimator(Model):
         outputs = OrderedDict()
         contexts_tgt, h_tgt = None, None
         contexts_src, h_src = None, None
-        if self.config.predict_target or self.config.predict_gaps:
+        if (
+            self.config.predict_target
+            or self.config.predict_gaps
+            or self.config.sentence_level
+        ):
             model_out_tgt = self.predictor_tgt(batch)
             input_seq, target_lengths = self.make_input(
                 model_out_tgt, batch, const.TARGET_TAGS

--- a/tests/test_predest.py
+++ b/tests/test_predest.py
@@ -72,6 +72,7 @@ def source_opts(predest_opts_multitask):
     options.predict_target = False
     options.predict_gaps = False
     options.predict_source = True
+    options.sentence_level = False
     return options
 
 


### PR DESCRIPTION
This is a response to #18. The possibility of training an estimator solely for sentence-level hadn't been considered.

The estimator part of the predictor-estimator model erroneously required one of the predict-{target, source, gaps} flag to be active. 

Furthermore the estimator always required `train-target-tags` flag to be passed. This doesn't make sense when training solely for sentence-level.