### PR TITLE
Update default train estimator config

### DIFF
--- a/experiments/train_estimator.yaml
+++ b/experiments/train_estimator.yaml
@@ -2,6 +2,9 @@
 
 model: estimator
 
+# Model Files will be saved here
+output-dir: runs/estimator
+
 #### MODEL SPECIFIC OPTS ####
 
 ## ESTIMATOR ##
@@ -50,10 +53,6 @@ source-bad-weight: 2.5
 predict-gaps: false
 target-bad-weight: 2.5
 
-### GENERAL OPTS ###
-
-# Do not set or set to negative number for CPU
-gpu-id: 0
 
 ### TRAIN OPTS ###
 epochs: 10
@@ -113,3 +112,11 @@ valid-source: data/WMT17/word_level/dev.src
 valid-target: data/WMT17/word_level/dev.mt
 valid-pe: data/WMT17/word_level/dev.pe
 valid-target-tags: data/WMT17/word_level/dev.tags
+
+
+### GENERAL OPTS ###
+
+# Experiment Name for MLFlow
+experiment-name: EN-DE Train Estimator
+# Do not set or set to negative number for CPU
+gpu-id: 0


### PR DESCRIPTION
Added experiment-name to be consistent with `train_predictor.yaml`
Similarly added output-dir (`runs/estimator/`), otherwise, the model would be saved in a directory with a randomly generated name (e.g. `runs/9jaakbq7277p7sd9lquv/`).