### PR TITLE
Fix docs of loading predictor when training estimator

### DIFF
--- a/kiwi/cli/models/predictor_estimator.py
+++ b/kiwi/cli/models/predictor_estimator.py
@@ -358,13 +358,13 @@ def add_training_options(training_parser):
         '--load-pred-source',
         type=PathType(exists=True),
         help='If set, model architecture and vocabulary parameters are '
-        'ignored. Load pretrained predictor src->tgt.',
+        'ignored. Load pretrained predictor tgt->src.',
     )
     group.add_argument(
         '--load-pred-target',
         type=PathType(exists=True),
         help='If set, model architecture and vocabulary parameters are '
-        'ignored. Load pretrained predictor tgt->src.',
+        'ignored. Load pretrained predictor src->tgt.',
     )
 
     group.add_argument(


### PR DESCRIPTION

The docs for the flags:
` --load-pred-target` and `--load-pred-source` were inconsistent with their naming. 
They were marked as tgt->src and src->tgt respectively. 

After analysis of the code it was clear that the docs were wrong. We can see in kiwi/models/predictor_estimator.py line 324 that Pred-target is used in the src->tgt direction (when predicting target).