### PR TITLE
Fix poetry command at the end of install doc

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -81,5 +81,5 @@ MLflow integration
 
 **Or** in case you have installed OpenKiwi as a local package, you should add mlflow to your env with::
    
-   poetry install -e mlflow
+   poetry install -E mlflow
 


### PR DESCRIPTION
`-e` flag is not licit for `poetry install`, it should be `-E`