### PR TITLE
Fix formating error with parameter logging

### DIFF
--- a/kiwi/lib/train.py
+++ b/kiwi/lib/train.py
@@ -187,7 +187,9 @@ def run(ModelClass, output_dir, pipeline_options, model_options):
 
     logger.info(str(trainer.model))
     logger.info("{} parameters".format(trainer.model.num_parameters()))
-    tracking_logger.log_param("model_parameters", trainer.model.num_parameters())
+    tracking_logger.log_param(
+        "model_parameters", trainer.model.num_parameters()
+    )
 
     # Dataset iterators
     train_iter = build_bucket_iterator(


### PR DESCRIPTION
By mistake the last PR we merged to master (#50) didn't conform to our formatting guidelines. 
This was undetected until we merged due to a misconfiguration which prevented our CI pipeline from running on this PR. 

@francoishernandez This was on me, I didn't notice the CI wasn't running, but FYI, we'd appreciate if you could run flake8 and/or black before opening a PR :) 

By using black we guarantee all our code is written under the same guidelines!