### PR TITLE
Fix poetry setting that was breaking circleCI checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
                   command: |
                       sudo apt-get update && sudo apt-get install -y --no-install-recommends libpython3.5-dev python3.5-dev
                       sudo pip install poetry
-                      poetry config settings.virtualenvs.create false
+                      export POETRY_VIRTUALENVS_CREATE=false
                       sudo pip install tox
             - run: tox -e lint
     test:
@@ -25,7 +25,7 @@ jobs:
                   command: |
                       sudo apt-get update && sudo apt-get install -y --no-install-recommends libpython3.5-dev python3.5-dev
                       sudo pip install poetry
-                      poetry config settings.virtualenvs.create false
+                      export POETRY_VIRTUALENVS_CREATE=false
                       sudo pip install tox
             - run:
                   name: CodeClimate before-build
@@ -55,7 +55,7 @@ jobs:
                   command: |
                       sudo apt-get update && sudo apt-get install -y --no-install-recommends libpython3.5-dev python3.5-dev openssh-client
                       sudo pip install poetry
-                      poetry config settings.virtualenvs.create false
+                      export POETRY_VIRTUALENVS_CREATE=false
                       sudo pip install tox
             - run:
                   name: Retrieve GH pages


### PR DESCRIPTION
Since poetry `1.0.0` the way settings are assigned has changed. (See [Pull request](https://github.com/python-poetry/poetry/pull/1272))

Since we always install poetry on a clean environment when running our CI we need to adopt these new practices for the CI to keep working correctly.