### PR TITLE
Add "to" method to move Predicter objects to other devices (#60) 

### DIFF
--- a/kiwi/predictors/predictor.py
+++ b/kiwi/predictors/predictor.py
@@ -43,6 +43,16 @@ class Predicter:
         # Will break in Multi GPU mode
         self._device = next(model.parameters()).device
 
+    def to(self, device):
+        """Method to mode Predicter object to other device. e.g: "cuda"
+
+        Args:
+          device (str): Device to which the model should be move to.
+        """
+
+        self._device = device
+        self.model.to(device)
+
     def predict(self, examples, batch_size=1):
         """Create Predictions for a list of examples.
 

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -64,7 +64,7 @@ def test_train_predictor(temp_output_dir, predictor_opts, train_opts, atol):
 
     trainer = train.run(Predictor, temp_output_dir, train_opts, predictor_opts)
     stats = trainer.stats_summary_history[-1]
-    np.testing.assert_allclose(stats['target_PERP'], 440.951923, atol=atol)
+    np.testing.assert_allclose(stats['target_PERP'], 440.262493, atol=atol)
 
     # Testing predictor with pickled data
     epoch_dir = 'epoch_{}'.format(train_opts.epochs)
@@ -72,7 +72,7 @@ def test_train_predictor(temp_output_dir, predictor_opts, train_opts, atol):
 
     trainer = train.run(Predictor, temp_output_dir, train_opts, predictor_opts)
     stats = trainer.stats_summary_history[-1]
-    np.testing.assert_allclose(stats['target_PERP'], 421.018286, atol=atol)
+    np.testing.assert_allclose(stats['target_PERP'], 420.706878, atol=atol)
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
This adds a simple API, consistent with Pytorch to move predicter Objects to different cuda devices.