### PR TITLE
Remove extra option that is never used

### DIFF
--- a/kiwi/systems/encoders/bert.py
+++ b/kiwi/systems/encoders/bert.py
@@ -99,8 +99,6 @@ class BertEncoder(MetaModule):
     """
 
     class Config(BaseConfig):
-        encode_source: bool = False
-
         model_name: Union[str, Path] = 'bert-base-multilingual-cased'
         """Pre-trained BERT model to use."""
 

--- a/kiwi/systems/encoders/predictor.py
+++ b/kiwi/systems/encoders/predictor.py
@@ -224,8 +224,6 @@ class PredictorEncoder(MetaModule):
     """
 
     class Config(BaseConfig):
-        encode_source: bool = False
-
         hidden_size: int = 400
         """Size of hidden layers in LSTM."""
 

--- a/kiwi/systems/encoders/xlm.py
+++ b/kiwi/systems/encoders/xlm.py
@@ -153,8 +153,6 @@ class XLMEncoder(MetaModule):
     """
 
     class Config(BaseConfig):
-        encode_source: bool = False
-
         model_name: Union[str, Path] = 'xlm-mlm-tlm-xnli15-1024'
         """Pre-trained XLM model to use."""
 

--- a/kiwi/systems/encoders/xlmroberta.py
+++ b/kiwi/systems/encoders/xlmroberta.py
@@ -104,8 +104,6 @@ class XLMRobertaEncoder(MetaModule):
     """XLM-RoBERTa model, using HuggingFace's implementation."""
 
     class Config(BaseConfig):
-        encode_source: bool = False
-
         model_name: Union[str, Path] = 'xlm-roberta-base'
         """Pre-trained XLMRoberta model to use."""
 

--- a/tests/test_bert.py
+++ b/tests/test_bert.py
@@ -39,7 +39,6 @@ model:
         freeze: false
         use_mismatch_features: false
         use_predictor_features: false
-        encode_source: false
 
     decoder:
         hidden_size: 16

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -30,7 +30,6 @@ batch_size:
 
 model:
     encoder:
-        encode_source: false
         hidden_size: 400
         rnn_layers: 2
         embeddings:

--- a/tests/test_xlm.py
+++ b/tests/test_xlm.py
@@ -34,7 +34,6 @@ model:
         model_name: None
         interleave_input: false
         freeze: false
-        encode_source: false
 
     decoder:
         hidden_size: 16

--- a/tests/test_xlmr.py
+++ b/tests/test_xlmr.py
@@ -34,7 +34,6 @@ model:
         model_name: None
         interleave_input: false
         freeze: false
-        encode_source: false
         pooling: mixed
 
     decoder:


### PR DESCRIPTION
The option `encode_source` is set as `False` by default in all encoders and is never used.

This is extremely misleading as all `train_config.yaml` saved after training have this option there, set as false. This implies that the models trained are never encoding source which is not true since the option is simply never used anywhere.
