### PR TITLE
Add config example to docs

### DIFF
--- a/config/search.yaml
+++ b/config/search.yaml
@@ -18,6 +18,7 @@ options:
     learning_rate:
         lower: 1e-7
         upper: 1e-5
+        distribution: loguniform  # recommended for the learning rate
     # Search weights for the tag loss
     class_weights:
         target_tags:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -28,6 +28,14 @@ For CLI usage, the general command is::
 Example configuration files can be found in ``config/``. Details are covered in
 :ref:`configuration`, including how to override options in the CLI.
 
+Alternatively, the same example configurations can be obtained by running::
+
+    kiwi (train|pretrain|predict|evaluate|search) --example
+
+This will print the config to the terminal, but can easily be redirected to a file::
+
+    kiwi train --example > train.yaml
+
 
 Training and pretraining
 ------------------------

--- a/kiwi/assets/config/pretrain.yaml
+++ b/kiwi/assets/config/pretrain.yaml
@@ -26,7 +26,6 @@ system:
 
     model:
         encoder:
-            encode_source: false
             hidden_size: 400
             rnn_layers: 2
             embeddings:

--- a/kiwi/assets/config/search.yaml
+++ b/kiwi/assets/config/search.yaml
@@ -18,6 +18,7 @@ options:
     learning_rate:
         lower: 1e-7
         upper: 1e-5
+        distribution: loguniform  # recommended for the learning rate
     # Search weights for the tag loss
     class_weights:
         target_tags:


### PR DESCRIPTION
We did not add the `--example` usage to the docs yet.