### PR TITLE
Fix bug that always downloads tokenizer files.

### DIFF
--- a/kiwi/systems/encoders/xlmroberta.py
+++ b/kiwi/systems/encoders/xlmroberta.py
@@ -45,9 +45,6 @@ logger = logging.getLogger(__name__)
 
 class XLMRobertaTextEncoder(TextEncoder):
     def __init__(self, tokenizer_name='xlm-roberta-base', is_source=False):
-        if tokenizer_name not in XLM_ROBERTA_PRETRAINED_MODEL_ARCHIVE_LIST:
-            tokenizer_name = 'xlm-roberta-base'
-
         tokenizer = AutoTokenizer.from_pretrained(str(tokenizer_name))
         wordpiece_tokenize = tokenizer._tokenize
 


### PR DESCRIPTION
When creating `XLMRobertaTextEncoder` object, the tokenizer name will be rewritten to `xlm-roberta-base` if a local model path is configured, so that the framework will always download the tokenizer files via the Internet (#102). This PR is to fix that.